### PR TITLE
ログイン用の画面を実装

### DIFF
--- a/client/src/components/LoginModal/LoginModal.module.css
+++ b/client/src/components/LoginModal/LoginModal.module.css
@@ -1,0 +1,34 @@
+.ModalContent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.ModalContent > input {
+  width: 80%;
+  margin-bottom: 10px;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+}
+
+.ModalContent > button {
+  width: 80%;
+  padding: 10px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  background-color: #ccc;
+  cursor: pointer;
+}
+
+.ModalContent > button:hover {
+  background-color: #ddd;
+}
+
+.ModalContent > label {
+  margin: 10px;
+  font-weight: bold;
+}

--- a/client/src/components/LoginModal/LoginModal.tsx
+++ b/client/src/components/LoginModal/LoginModal.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { apiClient } from 'src/utils/apiClient';
+import styles from './LoginModal.module.css';
+import Modal from './Modal';
+
+const LoginModal: React.FC = () => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [username, setUsername] = useState<string>('');
+
+  const handleButtonClick = async () => {
+    const player = await apiClient.player.create.$post({ body: { name: username } });
+    setIsModalOpen(false);
+  };
+  const onChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setUsername(e.target.value);
+  };
+
+  return (
+    <div>
+      <button onClick={() => setIsModalOpen(true)}>モーダルを開く</button>
+      <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
+        <div className={styles.ModalContent}>
+          <h2>Mugen Sweeper</h2>
+          <label>ユーザー名:</label>
+          <input type="text" placeholder="ユーザー名を入力してください" onChange={onChangeInput} />
+          <button onClick={handleButtonClick}>はじめる</button>
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+export default LoginModal;

--- a/client/src/components/LoginModal/Modal.module.css
+++ b/client/src/components/LoginModal/Modal.module.css
@@ -1,0 +1,22 @@
+/* Modal.module.css */
+.modalBackdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modalContent {
+  background-color: white;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+  max-width: 500px;
+  width: 90%;
+}

--- a/client/src/components/LoginModal/Modal.tsx
+++ b/client/src/components/LoginModal/Modal.tsx
@@ -1,0 +1,28 @@
+// Modal.tsx
+import type { FC, MouseEvent } from 'react';
+import styles from './Modal.module.css';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+
+  children: React.ReactNode;
+}
+
+const Modal: FC<ModalProps> = ({ isOpen, onClose, children }) => {
+  if (!isOpen) return null;
+
+  const handleContentClick = (e: MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+  };
+
+  return (
+    <div className={styles.modalBackdrop}>
+      <div className={styles.modalContent} onClick={handleContentClick}>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/server/api/player/create/controller.ts
+++ b/server/api/player/create/controller.ts
@@ -1,0 +1,6 @@
+import { playerUseCase } from '$/useCase/playerUseCase';
+import { defineController } from './$relay';
+
+export default defineController(() => ({
+  post: async ({ body }) => ({ status: 200, body: await playerUseCase.create(body.name) }),
+}));

--- a/server/api/player/create/index.ts
+++ b/server/api/player/create/index.ts
@@ -1,0 +1,11 @@
+import type { PlayerModel } from '$/commonTypesWithClient/models';
+import type { DefineMethods } from 'aspida';
+
+export type Methods = DefineMethods<{
+  post: {
+    reqBody: {
+      name: string;
+    };
+    resBody: PlayerModel | null;
+  };
+}>;

--- a/server/api/player/create/index.ts
+++ b/server/api/player/create/index.ts
@@ -1,5 +1,5 @@
-import type { PlayerModel } from '$/commonTypesWithClient/models';
 import type { DefineMethods } from 'aspida';
+import type { PlayerModel } from './../../../commonTypesWithClient/models';
 
 export type Methods = DefineMethods<{
   post: {


### PR DESCRIPTION
## 内容

ログイン用の画面を実装

## 変更点
- Playerを作成するエンドポイントをapi/player/createに作成
- ログイン用のモーダルを作成
    - DBへの書き込みまで動作することを確認しています

## 関連 Issue

close #28 

## スクリーンショット・動画など

![スクリーンショット 2023-08-19 21 23 45](https://github.com/INIAD-Developers/Mugen-sweeper/assets/36080294/3d7ead14-f77c-4f6c-b7c7-293477d7f9fe)


## その他
- CSSはコントローラー側と合わせたいので仮置きです