### PR TITLE
add game画面周りのAPIと分割

### DIFF
--- a/client/src/utils/minesweeperUtils.ts
+++ b/client/src/utils/minesweeperUtils.ts
@@ -22,4 +22,18 @@ export const minesweeperUtils = {
       .map((row) => row.slice(Math.max(0, x - 1), Math.min(x + 2, row.length)))
       .flat()
       .filter((b) => b === 1).length ?? 1 - 1,
+  makeBoard: (x: number, y: number, board: boardModel, bombMap: boardModel): boardModel => {
+    const newBoard = JSON.parse(JSON.stringify(board));
+    const openSurroundingCells = (x: number, y: number) => {
+      newBoard[y][x] = minesweeperUtils.countAroundBombsNum(bombMap, x, y);
+
+      if (newBoard[y][x] === 0) {
+        minesweeperUtils.aroundCellToArray(newBoard, x, y).forEach((nextPos) => {
+          openSurroundingCells(nextPos.x, nextPos.y);
+        });
+      }
+    };
+    openSurroundingCells(x, y);
+    return newBoard;
+  },
 };

--- a/server/api/game/ranking/controller.ts
+++ b/server/api/game/ranking/controller.ts
@@ -1,0 +1,6 @@
+import { gameUseCase } from '$/useCase/gameUseCase';
+import { defineController } from './$relay';
+
+export default defineController(() => ({
+  get: async () => ({ status: 200, body: await gameUseCase.getRanking(10) }),
+}));

--- a/server/api/game/ranking/index.ts
+++ b/server/api/game/ranking/index.ts
@@ -1,5 +1,5 @@
-import type { PlayerModel } from '../../../commonTypesWithClient/models'
 import type { DefineMethods } from 'aspida';
+import type { PlayerModel } from '../../../commonTypesWithClient/models';
 
 export type Methods = DefineMethods<{
   get: {

--- a/server/api/game/ranking/index.ts
+++ b/server/api/game/ranking/index.ts
@@ -1,0 +1,8 @@
+import type { PlayerModel } from '../../../commonTypesWithClient/models'
+import type { DefineMethods } from 'aspida';
+
+export type Methods = DefineMethods<{
+  get: {
+    resBody: PlayerModel[];
+  };
+}>;

--- a/server/api/player/config/controller.ts
+++ b/server/api/player/config/controller.ts
@@ -1,0 +1,9 @@
+import { playerUseCase } from '$/useCase/playerUseCase';
+import { defineController } from './$relay';
+
+export default defineController(() => ({
+  post: async ({ body }) => ({
+    status: 201,
+    body: await playerUseCase.create(body.name, body.userId),
+  }),
+}));

--- a/server/api/player/config/index.ts
+++ b/server/api/player/config/index.ts
@@ -1,5 +1,5 @@
-import type { UserId } from '../../../commonTypesWithClient/branded';
 import type { DefineMethods } from 'aspida';
+import type { UserId } from '../../../commonTypesWithClient/branded';
 import type { PlayerModel } from '../../../commonTypesWithClient/models';
 
 export type Methods = DefineMethods<{

--- a/server/api/player/config/index.ts
+++ b/server/api/player/config/index.ts
@@ -1,0 +1,10 @@
+import type { UserId } from '../../../commonTypesWithClient/branded';
+import type { DefineMethods } from 'aspida';
+import type { PlayerModel } from '../../../commonTypesWithClient/models';
+
+export type Methods = DefineMethods<{
+  post: {
+    reqBody: { userId: UserId; name: string };
+    resBody: PlayerModel | null;
+  };
+}>;

--- a/server/api/player/controller.ts
+++ b/server/api/player/controller.ts
@@ -2,6 +2,5 @@ import { playerUseCase } from '$/useCase/playerUseCase';
 import { defineController } from './$relay';
 
 export default defineController(() => ({
-  get: async () => ({ status: 200, body: await playerUseCase.findAll() }),
   post: async ({ body }) => ({ status: 201, body: await playerUseCase.move(body) }),
 }));

--- a/server/api/player/index.ts
+++ b/server/api/player/index.ts
@@ -2,9 +2,6 @@ import type { DefineMethods } from 'aspida';
 import type { PlayerModel } from './../../commonTypesWithClient/models';
 
 export type Methods = DefineMethods<{
-  get: {
-    resBody: PlayerModel[];
-  };
   post: {
     reqBody: PlayerModel;
     resBody: PlayerModel;

--- a/server/useCase/playerUseCase.ts
+++ b/server/useCase/playerUseCase.ts
@@ -2,14 +2,12 @@ import type { UserId } from '$/commonTypesWithClient/branded';
 import type { PlayerModel } from '$/commonTypesWithClient/models';
 import { GAME_SIZE } from '$/constants/gameSize';
 import { playersRepository } from '$/repository/playersRepository';
-import { userIdParser } from '$/service/idParsers';
 import { minMax } from '$/service/minMax';
-import { randomUUID } from 'crypto';
 
 export const playerUseCase = {
-  create: async (userName: string): Promise<PlayerModel | null> => {
+  create: async (userName: string, userId: UserId): Promise<PlayerModel | null> => {
     const newPlayerModel = {
-      id: userIdParser.parse(randomUUID()),
+      id: userId,
       x: Math.floor(Math.random() * GAME_SIZE.WIDTH),
       y: Math.floor(Math.random() * GAME_SIZE.HEIGHT),
       name: userName,
@@ -33,10 +31,6 @@ export const playerUseCase = {
   },
   getYourState: async (userId: UserId) => {
     const res = await playersRepository.find(userId);
-    return res;
-  },
-  findAll: async () => {
-    const res = await playersRepository.findAll();
     return res;
   },
 };


### PR DESCRIPTION
## 内容

game画面を取得するためのapiを整備し、表示できるように

## 変更点

- apiを追加
- playerのcreateの引数にuserIdを追加
- ボードを生成する関数を分割
